### PR TITLE
Updated for weak set iteration fix

### DIFF
--- a/Example/Tests/WeakObjectSetTestCase.swift
+++ b/Example/Tests/WeakObjectSetTestCase.swift
@@ -30,9 +30,22 @@ class WeakObjectSetTestCase: XCTestCase {
                 XCTFail("Expected object")
                 return
             }
-            XCTAssertEqual(testSet.count, 0)
+            let originalCount = testSet.count
             self.testSet.addObject(object: actualObject)
-            XCTAssertEqual(testSet.count, 1)
+            XCTAssertEqual(testSet.count, originalCount + 1)
+        }
+    }
+    
+    func addObjectActivity(multiple objects: [Test?]) {
+        XCTContext.runActivity(named: "Add Multiple Objects") { (activity) in
+            XCTAssertNotNil(testSet)
+            XCTAssertEqual(testSet.count, 0)
+            var addedObjects = 0
+            objects.forEach({ (testObject) in
+                addObjectActivity(with: testObject)
+                addedObjects += 1
+            })
+            XCTAssertEqual(testSet.count, addedObjects)
         }
     }
     
@@ -72,14 +85,14 @@ class WeakObjectSetTestCase: XCTestCase {
     }
     
     func testAddMultipleObjects() {
-        XCTAssertNotNil(testSet)
         XCTAssertEqual(testSet.count, 0)
         XCTAssertFalse(testSet.contains(object: firstTestObject))
         XCTAssertFalse(testSet.contains(object: secondTestObject))
-        self.testSet.addObjects(objects: [firstTestObject!, secondTestObject!])
+        addObjectActivity(multiple: [firstTestObject, secondTestObject])
         XCTAssertEqual(testSet.count, 2)
         XCTAssertTrue(testSet.contains(object: firstTestObject))
         XCTAssertTrue(testSet.contains(object: secondTestObject))
+
     }
     
     func testHoldWeakReferenceToObjects() {
@@ -90,6 +103,28 @@ class WeakObjectSetTestCase: XCTestCase {
         XCTAssertEqual(testSet.count, 0)
         print(testSet.allObjects)
         print(testSet.objects)
+    }
+    
+    func testForEach() {
+        addObjectActivity(multiple: [firstTestObject, secondTestObject])
+        XCTAssertEqual(testSet.count, 2)
+        XCTAssertTrue(testSet.contains(object: firstTestObject))
+        XCTAssertTrue(testSet.contains(object: secondTestObject))
+        
+        var iteration = 0
+        testSet.forEach { (testObject) -> (Void) in
+            guard let actualTestObject = testObject else {
+                XCTFail("We should always have a value in this test")
+                return
+            }
+            // Why do these throw warnings? Either way this is a smoke test at least
+//            XCTAssertTrue(actualTestObject is Test)
+//            XCTAssertTrue(actualTestObject.value is Int)
+            XCTAssertEqual(actualTestObject.value, iteration)
+            iteration += 1
+//            XCTAssertEqual(type(of: actualTestObject), Test.self)
+//            XCTAssertEqual(type(of: actualTestObject.value), Int.self)
+        }
     }
     
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - SwiftyKit (0.2.1)
+  - SwiftyKit (0.2.2)
 
 DEPENDENCIES:
   - SwiftyKit (from `.`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: .
 
 SPEC CHECKSUMS:
-  SwiftyKit: f5f94360388a377a969eb099c2fc6e51fdf7dbdf
+  SwiftyKit: c0737d053f7cd1b71e39310faf147c8e7dcc1d56
 
 PODFILE CHECKSUM: bda0d000543051513b2b00db40e0a516edb591d5
 

--- a/SwiftyKit.podspec
+++ b/SwiftyKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftyKit'
-  s.version          = '0.2.1'
+  s.version          = '0.2.2'
   s.summary          = 'A collection of best practices and quick tricks.'
 
 # This description is used to generate tags and improve search results.

--- a/SwiftyKit/Classes/WeakObjectSet.swift
+++ b/SwiftyKit/Classes/WeakObjectSet.swift
@@ -68,7 +68,9 @@ public class WeakObjectSet<T: AnyObject> {
         //        self.objects.unionInPlace(objects.map { WeakObject(object: $0) })
     }
     
-    public func forEach(body: (WeakObject<T>) -> (Void)) {
-        self.objects.forEach(body)
+    public func forEach(body: (T?) -> (Void)) {
+        self.objects.forEach { (weakObject) in
+            body(weakObject.object)
+        }
     }
 }


### PR DESCRIPTION
I wasn't casting the object to it's necessary non generic type which meant the optional weak value wasn't being exposed. Oops. Easy enough fix with a smoke test to confirm the functionality works. Need to figure out how to compare types in XCTest